### PR TITLE
ci(pre-commit): Fix poetry pre-comit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,8 @@ repos:
       - id: poetry-lock
         files: "^(pyproject.toml|poetry.lock)$"
         always_run: false
+        args: ["--no-update"]
       - id: poetry-install
-        files: "^(pyproject.toml|poetry.lock)$"
-        always_run: false
         stages:
           - "post-checkout"
           - "post-merge"


### PR DESCRIPTION
Update the poetry install hook to run it in any cases
No update the poetry lock file with the poetry lock hook