### PR TITLE
feat: add Shift+Enter mode for message submission

### DIFF
--- a/basilisk/config/main_config.py
+++ b/basilisk/config/main_config.py
@@ -36,6 +36,7 @@ class ConversationSettings(BaseModel):
 	role_label_user: str | None = Field(default=None)
 	role_label_assistant: str | None = Field(default=None)
 	nav_msg_select: bool = Field(default=False)
+	shift_enter_mode: bool = Field(default=False)
 
 
 class ImagesSettings(BaseModel):

--- a/basilisk/gui/preferences_dialog.py
+++ b/basilisk/gui/preferences_dialog.py
@@ -188,6 +188,14 @@ class PreferencesDialog(wx.Dialog):
 		self.nav_msg_select.SetValue(self.conf.conversation.nav_msg_select)
 		conversation_group_sizer.Add(self.nav_msg_select, 0, wx.ALL, 5)
 
+		self.shift_enter_mode = wx.CheckBox(
+			conversation_group,
+			# Translators: A label for a checkbox in the preferences dialog
+			label=_("Send message with Enter, insert newline with Shift+Enter"),
+		)
+		self.shift_enter_mode.SetValue(self.conf.conversation.shift_enter_mode)
+		conversation_group_sizer.Add(self.shift_enter_mode, 0, wx.ALL, 5)
+
 		sizer.Add(conversation_group_sizer, 0, wx.ALL, 5)
 
 		images_group = wx.StaticBox(panel, label=_("Images"))
@@ -317,6 +325,9 @@ class PreferencesDialog(wx.Dialog):
 			self.role_label_assistant.GetValue()
 		)
 		self.conf.conversation.nav_msg_select = self.nav_msg_select.GetValue()
+		self.conf.conversation.shift_enter_mode = (
+			self.shift_enter_mode.GetValue()
+		)
 
 		self.conf.images.resize = self.image_resize.GetValue()
 		self.conf.images.max_height = int(self.image_max_height.GetValue())


### PR DESCRIPTION
- Added `shift_enter_mode` option in `ConversationSettings` to allow Shift+Enter for newline and Enter for message submission.
- Updated `on_prompt_key_down` method in `ConversationTab` to handle the new `shift_enter_mode`.
- Modified `on_submit` method in `ConversationTab` to prevent multiple submissions when the button is disabled.
- Added corresponding checkbox in `PreferencesDialog` to enable/disable `shift_enter_mode`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new setting to customize Enter key behavior in conversation input.
	- Added a checkbox in preferences to toggle message sending and newline insertion with Enter and Shift+Enter.

- **Bug Fixes**
	- Improved handling of keyboard events for better user experience when entering prompts.

- **Refactor**
	- Streamlined keyboard event handling logic for clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->